### PR TITLE
Add plugin utilities and Go formatters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ tags
 test.sh
 .luarc.json
 nvim
+error.log
 
 spell/
 lazy-lock.json

--- a/init.lua
+++ b/init.lua
@@ -634,6 +634,8 @@ require('lazy').setup({
       end,
       formatters_by_ft = {
         lua = { 'stylua' },
+        go = { 'gofmt', 'goimports' },
+
         -- Conform can also run multiple formatters sequentially
         -- python = { "isort", "black" },
         --

--- a/lua/custom/plugins/harpoon.lua
+++ b/lua/custom/plugins/harpoon.lua
@@ -1,0 +1,26 @@
+return {
+  'ThePrimeagen/harpoon',
+  branch = 'harpoon2',
+  dependencies = {
+    'nvim-lua/plenary.nvim',
+  },
+  config = function()
+    local harpoon = require 'harpoon'
+
+    harpoon:setup()
+
+    vim.keymap.set('n', '<leader>0', function()
+      harpoon.ui:toggle_quick_menu(harpoon:list())
+    end, { desc = 'Harpoon: Toggle quick menu' })
+
+    vim.keymap.set('n', '<leader>a', function()
+      harpoon:list():add()
+    end, { desc = 'Harpoon: Add new file' })
+
+    for i = 1, 9 do
+      vim.keymap.set('n', string.format('<leader>%d', i), function()
+        harpoon:list():select(i)
+      end, { desc = string.format('Harpoon: Select file %d', i) })
+    end
+  end,
+}

--- a/lua/custom/plugins/notify.lua
+++ b/lua/custom/plugins/notify.lua
@@ -1,0 +1,14 @@
+return {
+  'rcarriga/nvim-notify',
+  event = 'VeryLazy',
+  opts = {
+    stages = 'fade_in_slide_out',
+    timeout = 3000,
+    render = 'default',
+  },
+  config = function(_, opts)
+    local notify = require('notify')
+    notify.setup(opts)
+    vim.notify = notify
+  end,
+}

--- a/lua/custom/plugins/persistence.lua
+++ b/lua/custom/plugins/persistence.lua
@@ -1,0 +1,35 @@
+return {
+  'folke/persistence.nvim',
+  event = 'BufReadPre',
+  opts = {},
+  keys = {
+    {
+      '<leader>qs',
+      function()
+        require('persistence').load()
+      end,
+      desc = 'Restore session',
+    },
+    {
+      '<leader>ql',
+      function()
+        require('persistence').load { last = true }
+      end,
+      desc = 'Restore last session',
+    },
+    {
+      '<leader>qS',
+      function()
+        require('persistence').select()
+      end,
+      desc = 'Select a session to restore',
+    },
+    {
+      '<leader>qd',
+      function()
+        require('persistence').stop()
+      end,
+      desc = 'Stop session recording',
+    },
+  },
+}

--- a/lua/custom/plugins/trouble.lua
+++ b/lua/custom/plugins/trouble.lua
@@ -1,0 +1,81 @@
+return {
+  'folke/trouble.nvim',
+  opts = {
+    auto_preview = true,
+    modes = {
+      -- override the built-in diagnostics mode
+      diagnostics = {
+        preview = {
+          type = 'split',
+          relative = 'win',
+          position = 'right',
+          size = 0.5,
+        },
+      },
+      qflist = {
+        preview = {
+          type = 'split',
+          relative = 'win',
+          position = 'right',
+          size = 0.5,
+        },
+      },
+      -- PREVIEW float pinnted to the top right of the editor
+      --   preview = {
+      --     type = 'float',
+      --     relative = 'editor',
+      --     border = 'rounded',
+      --     title = 'Preview',
+      --     title_pos = 'center',
+      --     position = { 0, -2 },
+      --     size = { width = 0.3, height = 0.3 },
+      --     zindex = 200,
+      --   },
+      -- PREVIEW float split off window diagnostics
+      -- preview = {
+      --   type = 'split',
+      --   relative = 'win',
+      --   position = 'right',
+      --   size = 0.5,
+      -- },
+      -- PREVIEW float pinned to the bottom-right of the editor
+      -- preview = {
+      --   type = 'float',
+      --   relative = 'editor',
+      --   border = 'rounded',
+      --   -- row, col (negative col = from right edge)
+      --   position = { 1, -2 },
+      --   size = { width = 0.45, height = 0.40 },
+      --   zindex = 200,
+      -- },
+    },
+  },
+  cmd = 'Trouble',
+  keys = {
+    {
+      '<leader>xx',
+      '<cmd>Trouble diagnostics toggle<cr>',
+      desc = 'Diagnostics (Trouble)',
+    },
+    {
+      '<leader>xX',
+      '<cmd>Trouble diagnostics toggle filter.buf=0<cr>',
+      desc = 'Buffer Diagnostics (Trouble)',
+    },
+    {
+      '<leader>cs',
+      '<cmd>Trouble symbols toggle focus=false<cr>',
+      desc = 'Symbols (Trouble)',
+    },
+    {
+      '<leader>cl',
+      '<cmd>Trouble lsp toggle focus=false win.position=right<cr>',
+      desc = 'LSP Definitions / references / ... (Trouble)',
+    },
+    {
+      '<leader>xq',
+      '<cmd>Trouble qflist toggle<cr>',
+      desc = 'Quickfix List (Trouble)',
+    },
+  },
+}


### PR DESCRIPTION
## Summary
- add harpoon for quick file navigation and persistence for session management
- install nvim-notify for improved notifications and expose it via `vim.notify`
- wire up Trouble UI defaults and extend Conform to format Go buffers with gofmt and goimports
- expand gitignore for local error logs

## Testing
- not run