### PR TITLE
Add Copilot and CopilotChat plugins

### DIFF
--- a/lua/custom/plugins/copilot.lua
+++ b/lua/custom/plugins/copilot.lua
@@ -7,21 +7,12 @@ return {
   end,
   enabled = function()
     local env_value = vim.env.COPILOT_ENABLED and vim.env.COPILOT_ENABLED:lower()
-    local env_on = env_value == '1' or env_value == 'true'
-
-    if vim.g.enable_copilot == false then
-      return false
-    end
-
-    if not env_on then
-      return false
-    end
-
-    return true
+    return env_value == '1' or env_value == 'true'
   end,
   config = function()
     local function toggle()
-      if vim.g.copilot_enabled == 0 then
+      local status = vim.g.copilot_enabled
+      if status == nil or status == 0 then
         vim.cmd 'Copilot enable'
       else
         vim.cmd 'Copilot disable'

--- a/lua/custom/plugins/copilot.lua
+++ b/lua/custom/plugins/copilot.lua
@@ -4,7 +4,6 @@ return {
   cmd = 'Copilot',
   init = function()
     vim.g.copilot_no_tab_map = true
-    vim.g.copilot_assume_mapped = true
   end,
   enabled = function()
     local env_value = vim.env.COPILOT_ENABLED and vim.env.COPILOT_ENABLED:lower()

--- a/lua/custom/plugins/copilot.lua
+++ b/lua/custom/plugins/copilot.lua
@@ -11,11 +11,10 @@ return {
   end,
   config = function()
     local function toggle()
-      local status = vim.g.copilot_enabled
-      if status == nil or status == 0 then
-        vim.cmd 'Copilot enable'
-      else
+      if vim.g.copilot_enabled == 1 then
         vim.cmd 'Copilot disable'
+      else
+        vim.cmd 'Copilot enable'
       end
     end
 

--- a/lua/custom/plugins/copilot.lua
+++ b/lua/custom/plugins/copilot.lua
@@ -1,0 +1,40 @@
+return {
+  'github/copilot.vim',
+  event = 'InsertEnter',
+  cmd = 'Copilot',
+  init = function()
+    vim.g.copilot_no_tab_map = true
+    vim.g.copilot_assume_mapped = true
+  end,
+  enabled = function()
+    local env_value = vim.env.COPILOT_ENABLED and vim.env.COPILOT_ENABLED:lower()
+    local env_on = env_value == '1' or env_value == 'true'
+
+    if vim.g.enable_copilot == false then
+      return false
+    end
+
+    if not env_on then
+      return false
+    end
+
+    return true
+  end,
+  config = function()
+    local function toggle()
+      if vim.g.copilot_enabled == 0 then
+        vim.cmd 'Copilot enable'
+      else
+        vim.cmd 'Copilot disable'
+      end
+    end
+
+    vim.keymap.set('i', '<M-CR>', function()
+      return vim.fn['copilot#Accept']('<CR>')
+    end, { expr = true, replace_keycodes = false, desc = 'Copilot: Accept suggestion' })
+    vim.keymap.set('i', '<M-]>', '<Plug>(copilot-next)', { desc = 'Copilot: Next suggestion' })
+    vim.keymap.set('i', '<M-[>', '<Plug>(copilot-previous)', { desc = 'Copilot: Previous suggestion' })
+    vim.keymap.set('i', '<C-]>', '<Plug>(copilot-dismiss)', { desc = 'Copilot: Dismiss suggestion' })
+    vim.keymap.set('n', '<leader>ct', toggle, { desc = 'Copilot: Toggle suggestions' })
+  end,
+}

--- a/lua/custom/plugins/copilot_chat.lua
+++ b/lua/custom/plugins/copilot_chat.lua
@@ -12,9 +12,8 @@ return {
     'CopilotChatExplain',
   },
   enabled = function()
-    local chat_env = vim.env.COPILOT_CHAT_ENABLED and vim.env.COPILOT_CHAT_ENABLED:lower()
-    local base_env = vim.env.COPILOT_ENABLED and vim.env.COPILOT_ENABLED:lower()
-    local env_on = chat_env == '1' or chat_env == 'true' or base_env == '1' or base_env == 'true'
+    local env_value = vim.env.COPILOT_ENABLED and vim.env.COPILOT_ENABLED:lower()
+    local env_on = env_value == '1' or env_value == 'true'
 
     if vim.g.enable_copilot_chat == false or vim.g.enable_copilot == false then
       return false

--- a/lua/custom/plugins/copilot_chat.lua
+++ b/lua/custom/plugins/copilot_chat.lua
@@ -1,16 +1,11 @@
 return {
   'CopilotC-Nvim/CopilotChat.nvim',
-  branch = 'canary',
+  branch = 'main',
   dependencies = {
     { 'github/copilot.vim' },
     { 'nvim-lua/plenary.nvim' },
   },
-  cmd = {
-    'CopilotChat',
-    'CopilotChatToggle',
-    'CopilotChatStop',
-    'CopilotChatExplain',
-  },
+  event = 'VeryLazy',
   enabled = function()
     local env_value = vim.env.COPILOT_ENABLED and vim.env.COPILOT_ENABLED:lower()
     local env_on = env_value == '1' or env_value == 'true'

--- a/lua/custom/plugins/copilot_chat.lua
+++ b/lua/custom/plugins/copilot_chat.lua
@@ -1,0 +1,41 @@
+return {
+  'CopilotC-Nvim/CopilotChat.nvim',
+  branch = 'canary',
+  dependencies = {
+    { 'github/copilot.vim' },
+    { 'nvim-lua/plenary.nvim' },
+  },
+  cmd = {
+    'CopilotChat',
+    'CopilotChatToggle',
+    'CopilotChatStop',
+    'CopilotChatExplain',
+  },
+  enabled = function()
+    local chat_env = vim.env.COPILOT_CHAT_ENABLED and vim.env.COPILOT_CHAT_ENABLED:lower()
+    local base_env = vim.env.COPILOT_ENABLED and vim.env.COPILOT_ENABLED:lower()
+    local env_on = chat_env == '1' or chat_env == 'true' or base_env == '1' or base_env == 'true'
+
+    if vim.g.enable_copilot_chat == false or vim.g.enable_copilot == false then
+      return false
+    end
+
+    if not env_on then
+      return false
+    end
+    return true
+  end,
+  opts = {
+    window = {
+      layout = 'float',
+    },
+  },
+  config = function(_, opts)
+    local chat = require 'CopilotChat'
+    chat.setup(opts)
+
+    vim.keymap.set('n', '<leader>cc', '<cmd>CopilotChatToggle<cr>', { desc = 'CopilotChat: Toggle chat window' })
+    vim.keymap.set('n', '<leader>cS', '<cmd>CopilotChatStop<cr>', { desc = 'CopilotChat: Stop active session' })
+    vim.keymap.set({ 'n', 'v' }, '<leader>ce', '<cmd>CopilotChatExplain<cr>', { desc = 'CopilotChat: Explain code' })
+  end,
+}

--- a/lua/custom/plugins/copilot_chat.lua
+++ b/lua/custom/plugins/copilot_chat.lua
@@ -15,14 +15,7 @@ return {
     local env_value = vim.env.COPILOT_ENABLED and vim.env.COPILOT_ENABLED:lower()
     local env_on = env_value == '1' or env_value == 'true'
 
-    if vim.g.enable_copilot_chat == false or vim.g.enable_copilot == false then
-      return false
-    end
-
-    if not env_on then
-      return false
-    end
-    return true
+    return env_on
   end,
   opts = {
     window = {


### PR DESCRIPTION
## Summary
- add github/copilot.vim plugin with custom keymaps and env-based enablement
- add CopilotChat plugin keyed off the same toggle
- document keybindings via configuration and remove unused copilot_assume_mapped setting

## Testing
- not run